### PR TITLE
fix: wrong auth separator

### DIFF
--- a/src/alice_sign_tx.rs
+++ b/src/alice_sign_tx.rs
@@ -116,7 +116,7 @@ mod tests {
         let (user, pass) = our_rpc
             .auth()
             .unwrap()
-            .split('.')
+            .split(':')
             .map(str::to_string)
             .collect_tuple()
             .expect("auth was incorrectly passed (expected `user:pw`)");


### PR DESCRIPTION
Pretty sure this is meant to be `:` not `.`.