### PR TITLE
Keepalive with Fibonacci Backoff, fault tolerant + randomised + concurrent orchestrator signing logic and more

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ bitcoincore-rpc = "0.18"
 clap = { version = "4.4.10", features = ["derive", "env"] }
 env_logger = "0.10.1"
 frost-secp256k1-tr = { git = "https://github.com/mimoo/frost", branch = "mimoo/fix5" }
+futures = "0.3.30"
 hex = "0.4.3"
 home = "0.5.9"
 itertools = "0.12.0"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,15 @@ Jump straight to [usage](#usage) if you want to see some examples, but make sure
 
 ### Circom/snarkjs
 
-We build on top of the well-known [circom](https://github.com/iden3/circom)/[snarkjs](https://github.com/iden3/snarkjs) stack. 
+We build on top of the well-known [circom](https://github.com/iden3/circom)/[snarkjs](https://github.com/iden3/snarkjs) stack.
+
+To install `circom`, please follow [their guide](https://docs.circom.io/getting-started/installation/).
+
+To install `snarkjs`, just run:
+
+```
+npm install -g snarkjs@latest
+```
 
 ### Bitcoin wallet
 
@@ -44,7 +52,7 @@ There are two types of zkapps: [stateless](#stateless-zkapps) and [stateful](#st
 
 ### Stateless zkapps
 
-A stateless zkapp is single-use, and the bitcoin it locks can be redeemed by anyone who can provide a proof of correct execution. An example of a stateless zkapp is in [`examples/circuit/stateless.circom`](examples/circuit/stateless.circom) (which releases funds to anyone who can find the preimage of a hash function). 
+A stateless zkapp is single-use, and the bitcoin it locks can be redeemed by anyone who can provide a proof of correct execution. An example of a stateless zkapp is in [`examples/circuit/stateless.circom`](examples/circuit/stateless.circom) (which releases funds to anyone who can find the preimage of a hash function).
 A stateless zkapp must always contains one public input that authenticates the transaction that spends it:
 
 ```circom
@@ -66,7 +74,7 @@ $ zkbtc deploy-zkapp --circom-circuit-path examples/circuit/stateless.circom --s
 
 This will lock 1,000 satoshis in the zkapp and return the transaction ID of the transaction that deployed the zkapp. A stateless zkapp can be referenced by that transaction ID.
 
-Bob can then unlock the funds from the stateless zkapp  with the following command:
+Bob can then unlock the funds from the stateless zkapp with the following command:
 
 ```shell
 $ zkbtc use-zkapp --txid "e793bdd8dfdd9912d971790a5f385ad3f1215dce97e25dbefe5449faba632836" --circom-circuit-path examples/circuit/stateless.circom --proof-inputs '{"preimage":["1"]}' --recipient-address "tb1q6nkpv2j9lxrm6h3w4skrny3thswgdcca8cx9k6"
@@ -94,7 +102,7 @@ component main{public [prev_state, truncated_txid, amount_out, amount_in]} = Mai
 You can deploy a stateful zkapp with the following command:
 
 ```shell
-$ zkbtc deploy-zkapp --circom-circuit-path examples/circuit/stateful.circom --initial-state "1" --satoshi-amount 1000     
+$ zkbtc deploy-zkapp --circom-circuit-path examples/circuit/stateful.circom --initial-state "1" --satoshi-amount 1000
 ```
 
 You can use a stateful zkapps with the following command:
@@ -105,8 +113,8 @@ $ zkbtc use-zkapp --circom-circuit-path examples/circuit/stateful.circom --proof
 
 specifying the following inputs:
 
-* `amount_out`: amount being withdrawn
-* `amount_in`: amount being deposited
+- `amount_out`: amount being withdrawn
+- `amount_in`: amount being deposited
 
 Other inputs will be automatically filled in (for example, it will use the zkapp's state as `prev_state` input).
 

--- a/src/bin/zkbtc.rs
+++ b/src/bin/zkbtc.rs
@@ -404,6 +404,8 @@ async fn main() -> Result<()> {
                     let filename = format!("key-{id}.json");
 
                     let path = output_dir.join(filename);
+                    std::fs::create_dir_all(path.clone().parent().unwrap())
+                        .expect("Couldn't create directory");
                     let file = std::fs::File::create(&path)
                         .expect("couldn't create file given output dir");
                     serde_json::to_writer_pretty(file, key_package).unwrap();

--- a/src/committee/node.rs
+++ b/src/committee/node.rs
@@ -211,8 +211,8 @@ async fn round_2_signing(
     RpcResult::Ok(round2_response)
 }
 
-async fn is_alive(_params: Params<'static>, _context: Arc<NodeState>) -> String {
-    "hello".to_string()
+async fn is_alive(params: Params<'static>, _context: Arc<NodeState>) -> RpcResult<u64> {
+    Ok(params.parse::<[u64; 1]>()?[0].clone())
 }
 
 //
@@ -243,7 +243,7 @@ pub async fn run_server(
 
     module.register_async_method("round_1_signing", round_1_signing)?;
     module.register_async_method("round_2_signing", round_2_signing)?;
-    module.register_async_method("is_alive", is_alive)?;
+    module.register_async_method("ping", is_alive)?;
 
     let addr = server.local_addr()?;
     let handle = server.start(module);

--- a/src/committee/orchestrator.rs
+++ b/src/committee/orchestrator.rs
@@ -2,7 +2,8 @@ use std::{
     collections::{BTreeMap, HashMap},
     net::SocketAddr,
     str::FromStr,
-    sync::Arc,
+    sync::{Arc, RwLock},
+    time::{Duration, SystemTime},
 };
 
 use anyhow::{Context, Result};
@@ -13,18 +14,20 @@ use bitcoin::{
 };
 use frost_secp256k1_tr::Ciphersuite;
 use frost_secp256k1_tr::Group;
+use futures::future::join_all;
 use itertools::Itertools;
 use jsonrpsee::{server::Server, RpcModule};
 use jsonrpsee_core::RpcResult;
 use jsonrpsee_types::{ErrorObjectOwned, Params};
-use log::{debug, error, info};
+use log::{debug, error, info, warn};
 use secp256k1::XOnlyPublicKey;
 use serde::{Deserialize, Serialize};
+use tokio::time::sleep;
 
 use crate::{
     bob_request::{BobRequest, BobResponse},
     committee::node::Round1Response,
-    constants::ZKBITCOIN_PUBKEY,
+    constants::{KEEPALIVE_MAX_RETRIES, KEEPALIVE_WAIT_SECONDS, ZKBITCOIN_PUBKEY},
     frost,
     json_rpc_stuff::{json_rpc_request, RpcCtx},
     mpc_sign_tx::get_digest_to_hash,
@@ -36,10 +39,189 @@ use super::node::{Round2Request, Round2Response};
 // Orchestration logic
 //
 
+type RpcOrchestratorContext = Arc<(Orchestrator, Arc<RwLock<MemberStatusState>>)>;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CommitteeConfig {
     pub threshold: usize,
+    // TODO: We could use a Vec instead of a HashMap for the members, since it would be more efficient.
+    // We do not currently need hashmap functionality, but we might later, so left unchanged.
     pub members: HashMap<frost_secp256k1_tr::Identifier, Member>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum MemberStatus {
+    Online,
+    /// Disconnected members contain a tuple with the next connect retry time and the last retry number
+    Disconnected((u64, u8)),
+    /// Will no longer retry
+    Offline,
+}
+
+// This will be the second part in the RpcModule context wrapped in a RwLock.
+// I think this is better than including it in the actual CommitteeConfig since handlers will need
+// to wait for a read lock every time an rpc handler needs to access the config.
+// This way, handlers will only wait for read locks when they need the status of the members.
+pub struct MemberStatusState {
+    pub key_to_addr: HashMap<frost_secp256k1_tr::Identifier, String>,
+    pub status: HashMap<frost_secp256k1_tr::Identifier, MemberStatus>,
+}
+
+impl MemberStatusState {
+    pub async fn new(config: &CommitteeConfig) -> Self {
+        let mut key_to_addr = HashMap::new();
+        let mut status = HashMap::new();
+        let mut futures = Vec::with_capacity(config.members.len());
+
+        for (key, member) in config.members.iter() {
+            let _ = key_to_addr.insert(key.clone(), member.address.clone());
+            futures.push((
+                key.clone(),
+                Self::check_alive(member.address.clone()),
+                member.address.clone(),
+            ));
+        }
+
+        for (key, future, address) in futures.into_iter() {
+            let new_status = if future.await == true {
+                info!("{address} is online");
+                MemberStatus::Online
+            } else {
+                let delay = Self::get_next_fibonacci_backoff_delay(0);
+                warn!(
+                    "{address} is offline. Re-trying in {delay} seconds... (0/{KEEPALIVE_MAX_RETRIES})"
+                );
+                MemberStatus::Disconnected((Self::get_current_time_secs() + delay, 1))
+            };
+
+            let _ = status.insert(key, new_status);
+        }
+
+        Self {
+            key_to_addr,
+            status,
+        }
+    }
+
+    fn get_current_time_secs() -> u64 {
+        SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    }
+
+    fn fib(n: u64) -> u64 {
+        if n <= 0 {
+            return 0;
+        } else if n == 1 {
+            return 1;
+        } else {
+            return Self::fib(n - 1) + Self::fib(n - 2);
+        }
+    }
+
+    fn get_next_fibonacci_backoff_delay(retry: u8) -> u64 {
+        // Offset fib sequence by 5 to get better backoff times
+        Self::fib(retry as u64 + 5)
+    }
+
+    async fn check_alive(address: String) -> bool {
+        let data = Self::get_current_time_secs();
+        let rpc_ctx = RpcCtx::new(Some("2.0"), None, Some(address.clone()), None, None);
+        match json_rpc_request(
+            &rpc_ctx,
+            "ping",
+            &[serde_json::value::to_raw_value(&data).unwrap()],
+        )
+        .await
+        {
+            Err(_) => false,
+            Ok(resp_str) => {
+                // Sanity check
+                if let Ok(resp) =
+                    serde_json::from_str::<bitcoincore_rpc::jsonrpc::Response>(&resp_str)
+                {
+                    if let Some(resp_data) = resp.result {
+                        resp_data.get().parse::<u64>().unwrap_or_default() == data
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                }
+            }
+        }
+    }
+
+    pub async fn keepalive_thread(state: Arc<RwLock<Self>>) {
+        debug!("Keepalive thread started");
+        loop {
+            // Sleep
+            sleep(Duration::from_secs(KEEPALIVE_WAIT_SECONDS)).await;
+            // Get array of members which are not *permanently* offline
+
+            let members_to_check = {
+                let r_lock = state.read().unwrap();
+                r_lock
+                    .key_to_addr
+                    .iter()
+                    .map(|(key, addr)| {
+                        let status = r_lock.status.get(key).unwrap().clone();
+                        (key.clone(), addr.clone(), status)
+                    })
+                    .filter(|(_, _, status)| match *status {
+                        MemberStatus::Online => true,
+                        MemberStatus::Disconnected((retry_time, _)) => {
+                            retry_time <= Self::get_current_time_secs()
+                        }
+                        _ => false,
+                    })
+                    .collect::<Vec<(frost_secp256k1_tr::Identifier, String, MemberStatus)>>()
+            };
+
+            // check alive for each one of them
+            let mut futures = Vec::with_capacity(members_to_check.len());
+            for member_data in members_to_check.iter() {
+                futures.push(Self::check_alive(member_data.1.clone()));
+            }
+
+            // resolve futures and update state
+            let keepalive_resp = join_all(futures).await;
+            for (idx, resp) in keepalive_resp.iter().enumerate() {
+                let (key, address, old_status) = &members_to_check[idx];
+                if *resp {
+                    if *old_status != MemberStatus::Online {
+                        let mut state_w = state.write().unwrap();
+                        let member_status = state_w.status.get_mut(key).unwrap();
+                        *member_status = MemberStatus::Online;
+                        info!("{address} is back online");
+                    } else {
+                        debug!("{address} is online");
+                    }
+                } else {
+                    let mut state_w = state.write().unwrap();
+                    let member_status = state_w.status.get_mut(key).unwrap();
+                    let last_retries = match old_status {
+                        MemberStatus::Disconnected((_, last_retry_number)) => *last_retry_number,
+                        _ => 0,
+                    };
+
+                    if last_retries > KEEPALIVE_MAX_RETRIES {
+                        error!("{address} is offline. Will not retry connection");
+                        *member_status = MemberStatus::Offline;
+                    } else {
+                        let new_retries = last_retries + 1;
+                        let delay = Self::get_next_fibonacci_backoff_delay(new_retries);
+                        warn!("{address} is offline. Re-trying in {delay} seconds... ({new_retries}/{KEEPALIVE_MAX_RETRIES})");
+                        *member_status = MemberStatus::Disconnected((
+                            Self::get_current_time_secs() + delay,
+                            new_retries,
+                        ));
+                    }
+                }
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -260,14 +442,14 @@ impl Orchestrator {
 /// Bob's request to unlock funds from a smart contract.
 async fn unlock_funds(
     params: Params<'static>,
-    context: Arc<Orchestrator>,
+    context: RpcOrchestratorContext,
 ) -> RpcResult<BobResponse> {
     // get bob request
     let bob_request: [BobRequest; 1] = params.parse()?;
     let bob_request = &bob_request[0];
     info!("received request: {:?}", bob_request);
 
-    let bob_response = context.handle_request(bob_request).await.map_err(|e| {
+    let bob_response = context.0.handle_request(bob_request).await.map_err(|e| {
         ErrorObjectOwned::owned(
             jsonrpsee_types::error::UNKNOWN_ERROR_CODE,
             "error while unlocking funds",
@@ -286,10 +468,17 @@ pub async fn run_server(
     let address = address.unwrap_or("127.0.0.1:6666");
     info!("- starting orchestrator at address http://{address}");
 
-    let ctx = Orchestrator {
-        pubkey_package,
-        committee_cfg,
-    };
+    let member_status_state = Arc::new(RwLock::new(MemberStatusState::new(&committee_cfg).await));
+    let mss_thread_copy = member_status_state.clone();
+    tokio::spawn(async move { MemberStatusState::keepalive_thread(mss_thread_copy).await });
+
+    let ctx = (
+        Orchestrator {
+            pubkey_package,
+            committee_cfg,
+        },
+        member_status_state.clone(),
+    );
 
     let server = Server::builder()
         .build(address.parse::<SocketAddr>()?)

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -37,3 +37,9 @@ pub const STATELESS_ZKAPP_PUBLIC_INPUT_LEN: usize = 1 /* truncated txid */;
 
 /// The expected number of public inputs for a stateful zkapp.
 pub const STATEFUL_ZKAPP_PUBLIC_INPUT_LEN: usize = 1 * 2 /* new state + prev state */ + 1 /* truncated txid */ + 1 /* amount_out */ + 1 /* amount_in */;
+
+/// The number of seconds to sleep between orchestrator-node keepalive requests
+pub const KEEPALIVE_WAIT_SECONDS: u64 = 5;
+
+/// The total number of fibonacci backoff retries before considering an MPC node offline
+pub const KEEPALIVE_MAX_RETRIES: u8 = 10;

--- a/src/json_rpc_stuff.rs
+++ b/src/json_rpc_stuff.rs
@@ -46,18 +46,18 @@ impl RpcCtx {
             timeout: timeout.unwrap_or(Duration::from_secs(JSON_RPC_TIMEOUT)),
         };
 
-        info!("- using RPC node at address {}", ctx.address());
+        debug!("- using RPC node at address {}", ctx.address());
 
         if ctx.auth().is_some() {
-            info!("- using given RPC credentials");
+            debug!("- using given RPC credentials");
         } else {
-            info!("- using no RPC credentials");
+            debug!("- using no RPC credentials");
         }
 
         if let Some(wallet) = ctx.wallet() {
-            info!("- using wallet {wallet}");
+            debug!("- using wallet {wallet}");
         } else {
-            info!("- using default wallet");
+            debug!("- using default wallet");
         }
 
         ctx

--- a/src/json_rpc_stuff.rs
+++ b/src/json_rpc_stuff.rs
@@ -5,7 +5,7 @@
 use anyhow::{Context, Result};
 use base64::{engine::general_purpose, Engine};
 use bitcoin::{Amount, Transaction, Txid};
-use log::{debug, info, log_enabled, Level};
+use log::{debug, log_enabled, Level};
 use reqwest::{
     header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE},
     Client,


### PR DESCRIPTION
Hi! This is a pretty interesting project. Read through the code and decided to help implement some stuff :)

## Issues
* closes #3 
* closes #4 

## Implemented Features
* `generate-committee` fails if the provided directory doesn't exist, it now creates it by default
* Keepalive between the orchestrator and MPC nodes with fibonacci backoff
* Updated rpc requests log levels from `info` to `debug`. Imho, info level logs shouldn't be spammed by low level request messages
* Made the orchestrator signing logic concurrent, random (maybe this will be replaced with a better selection algorithm in the future?) and fault tolerant
* Added a `status` method to the orchestrator jsonrpc which returns the alive/dead MPC nodes (using the key identifier, not address, which could be private to the orchestrator).
* Updated installation instructions - it was not very clear `circom` and `snarkjs` binaries are required to do stuff, so I changed the README to be more clear :)

Let's get into the exciting details!

## `MemberStatus`
A new `MemberStatus` enum was implemented which is used to classify the state of an MPC member inside the orchestrator:
* `Online` - The node is online and responsive
* `Disconnected` - The node is unresponsive but there will be reconnection attempts with fibonacci delays
* `Offline` - The node is unresponsive and reconnection will not be attempted anymore. This can happen either because we tried reconnecting too many times in the `Disconnected` state, or because the node generated a round 1 signing commitment but didn't manage to complete round 2, meaning it is very unreliable and maybe is running a different version than the other nodes.

The status of each node will be held inside a `RwLock<MemberStatusState>` structure which is passed inside the `jsonrpsee` context.

## `status` jsonrpc method
Pretty self explanatory, this is what the status method returns: 
```
curl -X POST http://127.0.0.1:8890 -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":"test","method":"status","params":[11]}'

{"jsonrpc":"2.0","result":{"online_members":["0000000000000000000000000000000000000000000000000000000000000001"],"offline_members":["0000000000000000000000000000000000000000000000000000000000000002","0000000000000000000000000000000000000000000000000000000000000003"]},"id":"test"}
```

## Fibonacci backoff keepalive
When the orchestrator starts, it will ping the newly implemented `ping` endpoint of each MPC member and determine if it's alive or not. It will keep on querying the ping endpoint every `KEEPALIVE_WAIT_SECONDS` seconds (defined in `constants.rs`). It will only ping `Online` or `Disconnected` nodes and update the status accordingly. The fibonacci backoff means that if a node doesn't respond (is in the `Disconnected` state), it will try again in 5, 8, 13, 21 etc seconds until it reaches a `KEEPALIVE_MAX_RETRIES` number of retries, when it will classify the node as `Offline`.

## New concurrent fault-tolerant signing logic
This is how the new logic works and is pretty fault tolerant:

1. The orchestrator generates a list of `Online` nodes and shuffles them.
2. If the number of available nodes is below the required threshold, the orchestrator returns a `not enough available signers` error.
3. The orchestrator picks first `n` nodes required for the threshold.
4. It then does the first signing round **concurrently**.
5. When checking the results, if any node has not returned a commitment, it classifies that node as `Disconnected` and jumps back to step 1. This way, it will try again with a new set of nodes.
6. Otherwise, it then does the second signing round **concurrently**.
7. When checking the results, if any node has not returned a signature, it classifies that node as `Offline` and jumps back to step 1.
8. Otherwise, it generates the transaction and returns Ok.

## Testing

I have tested every new feature, but I highly encourage you to test it out more!

In order to perform the tests for the fault tolerance, I created some new committee keys and spun up my own orchestrator and MPC nodes with a new `ZKBITCOIN` address. These are the tests I have performed and the results:

### Test 1
I tried "using" a zkapp while only 1/3 MPC nodes were online. I have received the following error, which is expected:
```
Error: error while sending request to orchestrator

Caused by:
    0: bob request failed
    1: RPC error response: RpcError { code: -32001, message: "error while unlocking funds", data: Some(RawValue("the request didn't validate: not enough available signers")) }
```

### Test 2
I spun up 2/3 nodes, but with a catch. One of the running nodes is going to panic when asked for round 2:
```rust
async fn round_2_signing(
    params: Params<'static>,
    context: Arc<NodeState>,
) -> RpcResult<Round2Response> {
    panic!("Panic for fun") // panic for testing
    // get commitments from params
    let round2request: [Round2Request; 1] = params.parse()?;
    let round2request = &round2request[0];
    info!("received request: {:?}", round2request);
```

The orchestrator didn't crash and just returned the same error as in test 1. This is because it tried doing the signing logic, but failed on step 2 and classified the failing node as `Offline`. It then tried again, but only saw 1/3 available nodes and returned the error.

```
[2024-01-25T01:33:07Z WARN  zkbitcoin::committee::orchestrator] Round 2 error with http://127.0.0.1:8891, marking as offline and retrying from round 1: error sending request for url (http://127.0.0.1:8891/): connection closed before message completed
[2024-01-25T01:33:09Z WARN  zkbitcoin::committee::orchestrator] http://127.0.0.1:8893 is offline. Re-trying in 34 seconds... (4/10)
```

### Test 3 - **the most important test**
I also did test 2 but with 3/3 nodes running, and only one of them will crash when asked for round 1 commitment. What happened is that it actually did randomly selected the *faulty* node, but when it didn't receive a commitment from it, it classified that node as `Disconnected`, and then tried again with the other 2 nodes and successfully generated a signature and submitted the spend transaction. This is great fault tolerance!

### Test 4
I spun up 2/3 nodes with no catches. This should work in this scenario, and it did.

Here is my `ZKBITCOIN` address: https://mempool.space/testnet/address/tb1przdyzca6zxlykmas4tvdum8qtac3m0ppsfm9p8akfckqkwnw07xs2u9cwf
There are 4 transactions: 2 deploys, one spent on test 3 and one spent on test 4

If you have something to add or any suggestions on what I implemented I would love to hear them!