### PR TITLE
Remove `zkapp_input`

### DIFF
--- a/docs/mpc.md
+++ b/docs/mpc.md
@@ -26,10 +26,6 @@ pub struct BobRequest {
     /// as we need to deconstruct the txid of the input of `tx`.
     pub zkapp_tx: Transaction,
 
-    /// The index of the input that contains the zkapp being used.
-    // TODO: we should be able to infer this!
-    pub zkapp_input: usize,
-
     /// The verifier key authenticated by the deployed transaction.
     pub vk: plonk::VerifierKey,
 

--- a/src/bob_request.rs
+++ b/src/bob_request.rs
@@ -342,7 +342,7 @@ impl BobRequest {
         Ok(res)
     }
 
-    pub fn zkapp_tx_with_witness(&self, witness: Witness) -> Result<Transaction> {
+    pub fn unlocked_tx(&self, witness: Witness) -> Result<Transaction> {
         let mut transaction = self.tx.clone();
 
         transaction

--- a/src/bob_request.rs
+++ b/src/bob_request.rs
@@ -355,17 +355,6 @@ impl BobRequest {
         Ok(transaction)
     }
 
-    fn add_zkapp_witness(&mut self, witness: Witness) -> Result<()> {
-        self.tx
-            .input
-            .iter_mut()
-            .find(|tx| tx.previous_output.txid == self.zkapp_tx.txid())
-            .context("couldn't find zkapp input in transaction")?
-            .witness = witness;
-
-        Ok(())
-    }
-
     /// The transaction ID and output index of the zkapp used in the request.
     fn zkapp_outpoint(&self) -> Result<OutPoint> {
         let outpoint = self

--- a/src/committee/orchestrator.rs
+++ b/src/committee/orchestrator.rs
@@ -507,12 +507,7 @@ impl Orchestrator {
             let mut witness = Witness::new();
             witness.push(final_signature.to_vec());
 
-            let mut transaction = bob_request.tx.clone();
-            transaction
-                .input
-                .get_mut(bob_request.zkapp_input)
-                .context("couldn't find zkapp input in transaction")?
-                .witness = witness;
+            let transaction = bob_request.zkapp_tx_with_witness(witness)?;
 
             // return the signed transaction
             return Ok(BobResponse {

--- a/src/committee/orchestrator.rs
+++ b/src/committee/orchestrator.rs
@@ -507,11 +507,9 @@ impl Orchestrator {
             let mut witness = Witness::new();
             witness.push(final_signature.to_vec());
 
-            let transaction = bob_request.zkapp_tx_with_witness(witness)?;
-
             // return the signed transaction
             return Ok(BobResponse {
-                unlocked_tx: transaction,
+                unlocked_tx: bob_request.unlocked_tx(witness)?,
             });
         }
     }


### PR DESCRIPTION
The index of the input that contains the `zkapp` being used is part of the `unlock_funds` RPC request. However, this is redundant since we can infer it from the unlock transaction inputs using the following equality check:

`tx.previous_output.txid == self.zkapp_tx.txid()`


Fixes https://github.com/sigma0-xyz/zkbitcoin/issues/6

