### PR TITLE
feat: implement a check to the latest version of the CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ Cargo.lock
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
 .vscode
+local_keys

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ num-bigint = "0.4.4"
 num-traits = "0.2.17"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
-reqwest = { version = "0.11", features = ["stream"] }
+reqwest = { version = "0.11", features = ["stream", "json"] }
 secp256k1 = "0.28.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
@@ -41,6 +41,7 @@ tokio = { version = "1.34", features = [
     "macros",
 ] }
 tokio-stream = "0.1.14"
+versions = "6.1.0"
 
 [patch.crates-io]
 # see docs/serialization.md

--- a/src/bin/zkbtc-admin.rs
+++ b/src/bin/zkbtc-admin.rs
@@ -6,6 +6,7 @@ use zkbitcoin::{
     committee::orchestrator::{CommitteeConfig, Member},
     constants::{ZKBITCOIN_FEE_PUBKEY, ZKBITCOIN_PUBKEY},
     frost, taproot_addr_from,
+    utils::version,
 };
 
 #[derive(Parser)]
@@ -76,6 +77,9 @@ async fn main() -> Result<()> {
         "- zkbitcoin_fund_address: {}",
         taproot_addr_from(ZKBITCOIN_FEE_PUBKEY).unwrap().to_string()
     );
+
+    // ignore if there is any error
+    let _ = version::check_version().await;
 
     // parse CLI
     let cli = Cli::parse();

--- a/src/bin/zkbtc.rs
+++ b/src/bin/zkbtc.rs
@@ -16,6 +16,7 @@ use zkbitcoin::{
     },
     snarkjs::{self, CompilationResult},
     taproot_addr_from,
+    utils::version,
 };
 
 #[derive(Parser)]
@@ -139,6 +140,9 @@ async fn main() -> Result<()> {
         "- zkbitcoin_fund_address: {}",
         taproot_addr_from(ZKBITCOIN_FEE_PUBKEY).unwrap().to_string()
     );
+
+    // ignore if there is any error
+    let _  = version::check_version().await;
 
     // parse CLI
     let cli = Cli::parse();

--- a/src/bin/zkbtc.rs
+++ b/src/bin/zkbtc.rs
@@ -142,7 +142,7 @@ async fn main() -> Result<()> {
     );
 
     // ignore if there is any error
-    let _  = version::check_version().await;
+    let _ = version::check_version().await;
 
     // parse CLI
     let cli = Cli::parse();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod json_rpc_stuff;
 pub mod plonk;
 pub mod snarkjs;
 pub mod srs;
+pub mod utils;
 
 /// 1. Alice signs a transaction to deploy a smart contract.
 pub mod alice_sign_tx;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod version;

--- a/src/utils/version.rs
+++ b/src/utils/version.rs
@@ -17,7 +17,7 @@ async fn fetch_latest_version() -> Result<Release> {
 
     let release = client
         .get(RELEASES_URL)
-        .header("User-Agent", "Rust CLI")
+        .header("User-Agent", "zkbitcoin cli")
         .send()
         .await?
         .json::<Release>()

--- a/src/utils/version.rs
+++ b/src/utils/version.rs
@@ -4,7 +4,7 @@ use reqwest::Client;
 use serde::Deserialize;
 use versions::Versioning;
 
-const RELEASES_URL: &str = "https://api.github.com/repos//sigma0-xyz/zkbitcoin/releases/latest";
+const RELEASES_URL: &str = "https://api.github.com/repos/sigma0-xyz/zkbitcoin/releases/latest";
 
 #[derive(Deserialize, Debug)]
 struct Release {

--- a/src/utils/version.rs
+++ b/src/utils/version.rs
@@ -4,8 +4,7 @@ use reqwest::Client;
 use serde::Deserialize;
 use versions::Versioning;
 
-const RELEASES_URL: &str =
-    "https://api.github.com/repos//sigma0-xyz/zkbitcoin/releases/latest";
+const RELEASES_URL: &str = "https://api.github.com/repos//sigma0-xyz/zkbitcoin/releases/latest";
 
 #[derive(Deserialize, Debug)]
 struct Release {

--- a/src/utils/version.rs
+++ b/src/utils/version.rs
@@ -4,7 +4,7 @@ use reqwest::Client;
 use serde::Deserialize;
 use versions::Versioning;
 
-const RELEASES_URL: &'static str =
+const RELEASES_URL: &str =
     "https://api.github.com/repos//sigma0-xyz/zkbitcoin/releases/latest";
 
 #[derive(Deserialize, Debug)]
@@ -30,7 +30,7 @@ async fn fetch_latest_version() -> Result<Release> {
 pub async fn check_version() -> Result<()> {
     let current_version = Versioning::new(env!("CARGO_PKG_VERSION"));
     let latest_release = fetch_latest_version().await?;
-    let latest_version = Versioning::new(&latest_release.tag_name.replace("v", ""));
+    let latest_version = Versioning::new(&latest_release.tag_name.replace('v', ""));
 
     if current_version < latest_version {
         warn!(

--- a/src/utils/version.rs
+++ b/src/utils/version.rs
@@ -1,0 +1,43 @@
+use anyhow::Result;
+use log::warn;
+use reqwest::Client;
+use serde::Deserialize;
+use versions::Versioning;
+
+const RELEASES_URL: &'static str =
+    "https://api.github.com/repos//sigma0-xyz/zkbitcoin/releases/latest";
+
+#[derive(Deserialize, Debug)]
+struct Release {
+    url: String,
+    tag_name: String,
+}
+
+async fn fetch_latest_version() -> Result<Release> {
+    let client = Client::new();
+
+    let release = client
+        .get(RELEASES_URL)
+        .header("User-Agent", "Rust CLI")
+        .send()
+        .await?
+        .json::<Release>()
+        .await?;
+
+    Ok(release)
+}
+
+pub async fn check_version() -> Result<()> {
+    let current_version = Versioning::new(env!("CARGO_PKG_VERSION"));
+    let latest_release = fetch_latest_version().await?;
+    let latest_version = Versioning::new(&latest_release.tag_name.replace("v", ""));
+
+    if current_version < latest_version {
+        warn!(
+            "You are using an old version. Please download the latest version: {}",
+            latest_release.url
+        )
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes https://github.com/sigma0-xyz/zkbitcoin/issues/11

The version is checked against the latest release which we can get from this [endpoint](https://api.github.com/repos//sigma0-xyz/zkbitcoin/releases/latest). We compare this version to the crate's version.

For this to work we would need:

1. Publish releases of new versions
2. The name of the tag should be prefixed with `v` e.g. `v0.1.0`
3. Bump crate version in Cargo.lock upon new release.